### PR TITLE
widen main content by percentage

### DIFF
--- a/src/css/vars-dark.css
+++ b/src/css/vars-dark.css
@@ -143,10 +143,10 @@
   --nav-width: calc(270 / var(--rem-base) * 1rem);
   --toc-top: calc(var(--body-top) + var(--toolbar-height));
   --toc-height: calc(100vh - var(--toc-top) - 2.5rem);
-  --toc-width: calc(162 / var(--rem-base) * 1rem);
-  --toc-width--widescreen: calc(216 / var(--rem-base) * 1rem);
-  --doc-max-width: calc(720 / var(--rem-base) * 1rem);
-  --doc-max-width--desktop: calc(828 / var(--rem-base) * 1rem);
+  --toc-width: calc(100% / 6);
+  --toc-width--widescreen: calc(100% / 6);
+  --doc-max-width: calc(100% - var(--toc-width));
+  --doc-max-width--desktop: calc(100% - var(--toc-width--widescreen));
   /* stacking */
   --z-index-nav: 1;
   --z-index-toolbar: 2;

--- a/src/css/vars.css
+++ b/src/css/vars.css
@@ -140,10 +140,10 @@
   --nav-width: calc(270 / var(--rem-base) * 1rem);
   --toc-top: calc(var(--body-top) + var(--toolbar-height));
   --toc-height: calc(100vh - var(--toc-top) - 2.5rem);
-  --toc-width: calc(162 / var(--rem-base) * 1rem);
-  --toc-width--widescreen: calc(216 / var(--rem-base) * 1rem);
-  --doc-max-width: calc(720 / var(--rem-base) * 1rem);
-  --doc-max-width--desktop: calc(828 / var(--rem-base) * 1rem);
+  --toc-width: calc(100% / 6);
+  --toc-width--widescreen: calc(100% / 6);
+  --doc-max-width: calc(100% - var(--toc-width));
+  --doc-max-width--desktop: calc(100% - var(--toc-width--widescreen));
   /* stacking */
   --z-index-nav: 1;
   --z-index-toolbar: 2;


### PR DESCRIPTION
Move to a percentage based calculation to determine toc and main content widths. Therefore, removing dead space in the far right hand side.

| Before | After | 
| ------ | ------ |
|  <img width="1792" alt="Screen Shot 2022-04-19 at 10 19 12 PM" src="https://user-images.githubusercontent.com/226476/164155870-b8894605-ed2e-4aa1-8dd7-3ac53b1f7b1d.png"> | <img width="1792" alt="Screen Shot 2022-04-19 at 10 19 29 PM" src="https://user-images.githubusercontent.com/226476/164155906-7522403d-7886-4299-a753-e0c611f0741b.png"> |

fixes #10

/cc @rpmcfong @csongnguyen 