### PR TITLE
add uirootpath to header src path

### DIFF
--- a/src/partials/head-scripts.hbs
+++ b/src/partials/head-scripts.hbs
@@ -2,4 +2,4 @@
     <script async src="https://www.googletagmanager.com/gtag/js?id={{this}}"></script>
     <script>function gtag(){dataLayer.push(arguments)};window.dataLayer=window.dataLayer||[];gtag('js',new Date());gtag('config','{{this}}')</script>
     {{/with}}
-    <script id="header-script" src="_/js/header.js" data-ui-root-path="_"></script>
+    <script id="header-script" src="{{{uiRootPath}}}/js/header.js" data-ui-root-path="_"></script>


### PR DESCRIPTION
caused by https://github.com/countableSet/antora-ui/pull/27

add `uiRootPath` to header script path, so modules other than root can load the file correctly.

`_/js/header.js`
vs 
`../_/js/header.js`

similar to the styles loading `<link rel="stylesheet" href="{{{uiRootPath}}}/css/site.css">`

cc https://github.com/countableSet/antora-ui/issues/28
