### PR TITLE
backport copy-to-clipboard ui root fallback and fix ui root config

### DIFF
--- a/src/js/06-copy-to-clipboard.js
+++ b/src/js/06-copy-to-clipboard.js
@@ -6,9 +6,9 @@
   var TRAILING_SPACE_RX = / +$/gm
 
   var config = (document.getElementById('site-script') || { dataset: {} }).dataset
-  var uiRootPath = config.uiRootPath == null ? '.' : config.uiRootPath
-  var svgAs = config.svgAs
   var supportsCopy = window.navigator.clipboard
+  var svgAs = config.svgAs
+  var uiRootPath = (config.uiRootPath == null ? window.uiRootPath : config.uiRootPath) || '.'
 
   ;[].slice.call(document.querySelectorAll('.doc pre.highlight, .doc .literalblock pre')).forEach(function (pre) {
     var code, language, lang, copy, toast, toolbox

--- a/src/js/header/01-root.js
+++ b/src/js/header/01-root.js
@@ -1,8 +1,4 @@
 'use strict'
-
-// eslint-disable-next-line no-unused-vars
-var uiRootPath = '_'
-
 if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
   document.documentElement.setAttribute('data-theme', 'dark')
 }

--- a/src/partials/head-scripts.hbs
+++ b/src/partials/head-scripts.hbs
@@ -2,4 +2,4 @@
     <script async src="https://www.googletagmanager.com/gtag/js?id={{this}}"></script>
     <script>function gtag(){dataLayer.push(arguments)};window.dataLayer=window.dataLayer||[];gtag('js',new Date());gtag('config','{{this}}')</script>
     {{/with}}
-    <script id="header-script" src="{{{uiRootPath}}}/js/header.js" data-ui-root-path="_"></script>
+    <script id="header-script" src="{{{uiRootPath}}}/js/header.js" data-ui-root-path="{{{uiRootPath}}}"></script>


### PR DESCRIPTION
backport commit from upstream https://gitlab.com/antora/antora-ui-default/-/commit/91de243e4cd1d84effe43af31c1e01e7231ba568

- also remove uiRootPath from header root script since it was commented out in the upstream
- fix `data-ui-root-path="_"` to actually use the variable 🤦🏻‍♀️ 

```
<script id="site-script" src="../_/js/site.js" data-ui-root-path="../_"></script>
```

safari console:
```
> document.getElementById('site-script').dataset
< DOMStringMap = $3
uiRootPath: "../_"
DOMStringMap Prototype
```

cc https://github.com/countableSet/antora-ui/issues/28